### PR TITLE
Feature/jp unique errors

### DIFF
--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -208,16 +208,6 @@ class ReportPortalReporter extends Reporter {
         level: LEVEL.ERROR,
         message,
       });
-
-      // if (this.options.cucumberNestedSteps) {
-      //   const suiteItem = this.storage.getCurrentSuite();
-      //   const foo = `Scenario: ${suiteItem.wdioEntity.title}`; // , Step: ${test.title}, Error: ${test.error.stack}`;
-      //   console.log('Error', foo);
-      //   this.client.sendLog(suiteItem.id, {
-      //     level: LEVEL.ERROR,
-      //     foo,
-      //   });
-      // }
     }
 
     const {promise} = this.client.finishTestItem(testItem.id, finishTestObj);

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -83,6 +83,7 @@ class ReportPortalReporter extends Reporter {
               value: this.featureName,
             },
           ];
+          console.log(`Scenario Title: ${suite.title}`);
           break;
       }
     }
@@ -192,20 +193,31 @@ class ReportPortalReporter extends Reporter {
 
     const finishTestObj = new EndTestItem(status, issue);
     if (status === STATUS.FAILED) {
-      const message = `${test.error.stack} `;
+      let message = `${test.error.stack}`;
+
+      if (this.options.cucumberNestedSteps) {
+        const suiteItem = this.storage.getCurrentSuite();
+        message = `${message}
+        Scenario: ${suiteItem.wdioEntity.title}
+        Step: ${test.title}
+        `;
+      }
+
       finishTestObj.description = `❌ ${message}`;
       this.client.sendLog(testItem.id, {
         level: LEVEL.ERROR,
         message,
       });
 
-      if (this.options.cucumberNestedSteps) {
-        const suiteItem = this.storage.getCurrentSuite();
-        this.client.sendLog(suiteItem.id, {
-          level: LEVEL.ERROR,
-          message,
-        });
-      }
+      // if (this.options.cucumberNestedSteps) {
+      //   const suiteItem = this.storage.getCurrentSuite();
+      //   const foo = `Scenario: ${suiteItem.wdioEntity.title}`; // , Step: ${test.title}, Error: ${test.error.stack}`;
+      //   console.log('Error', foo);
+      //   this.client.sendLog(suiteItem.id, {
+      //     level: LEVEL.ERROR,
+      //     foo,
+      //   });
+      // }
     }
 
     const {promise} = this.client.finishTestItem(testItem.id, finishTestObj);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4798,6 +4798,8 @@
     },
     "reportportal-js-client": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/reportportal-js-client/-/reportportal-js-client-2.0.0.tgz",
+      "integrity": "sha512-nKuWlFTdwBrzDXugCLOu5JDhMLYUuAS6ptRqKuW72HIPIYm7LW3c0TVhnhTYA204iCrX+PF2E2eJ15lHZlImyw==",
       "requires": {
         "axios": "0.19.2",
         "axios-retry": "3.1.2",


### PR DESCRIPTION
## Proposed changes
Adds scenario and step info to the error message to help with auto analysis so it stays scoped to the scenario/step.  Otherwise with cucumber, if an error occurs with a step and it occurs in another scenario it'll get marked with the same issue instead of different issues.

